### PR TITLE
Update sass-rails to sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'haml'
 gem 'haml-rails'
 gem 'bootstrap-sass', '~> 3.4.1'
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '~> 2.1.0'
 # gem 'font-awesome-sass', '~> 4.2.0'
 gem 'font-awesome-rails', '~> 4.5.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,9 +149,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rdoc (4.3.0)
     regexp_parser (1.3.0)
     rspec-core (3.8.0)
@@ -173,20 +170,15 @@ GEM
     rspec-support (3.8.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
-    sass (3.7.3)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -238,7 +230,7 @@ DEPENDENCIES
   rails (~> 5.0.7, >= 5.0.7.2)
   rails_12factor
   rspec-rails (~> 3.0)
-  sass-rails (~> 5.0)
+  sassc-rails (~> 2.1.0)
   sdoc (~> 0.4.0)
   spring
   sqlite3

--- a/app/assets/stylesheets/custom.sass
+++ b/app/assets/stylesheets/custom.sass
@@ -16,20 +16,19 @@ body
 .btn.btn-link
   text-decoration: none
 
-/* Custom, iPhone Retina */
-@media only screen and (max-width : 320px)
+// /* Custom, iPhone Retina */
+// @media only screen and (max-width : 320px)
 
-/* Extra Small Devices, Phones */
-@media only screen and (max-width : 480px)
+// /* Extra Small Devices, Phones */
+// @media only screen and (max-width : 480px)
 
-
-/* Small Devices, Tablets */
-@media only screen and (max-width : 768px)
+// /* Small Devices, Tablets */
+// @media only screen and (max-width : 768px)
 
 /* Medium Devices, Desktops */
 @media only screen and (max-width : 992px)
   .text-remover
     display: none
 
-/* Large Devices, Wide Screens */
-@media only screen and (max-width : 1200px)
+// /* Large Devices, Wide Screens */
+// @media only screen and (max-width : 1200px)


### PR DESCRIPTION
comment out empty media queries because it raises following error, and I think they are only placeholders for any styling in the future.

```
ActionView::Template::Error (Error: Invalid CSS after "...-width : 320px)": expected "{", was ";"
        on line 20 of app/assets/stylesheets/custom.sass
        from line 7 of app/assets/stylesheets/application.sass
>> @media only screen and (max-width : 320px);

   -----------------------------------------^
):
```