### PR TITLE
Fix done_at bug

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,7 +11,8 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = current_user.tasks.new(task_params).start_done_at
+    @task = current_user.tasks.new(task_params)
+    @task.start_done_at
     if @task.save
       redirect_to tasks_url, notice: "Task Added!"
     else
@@ -26,7 +27,8 @@ class TasksController < ApplicationController
   end
 
   def clear
-    @task.start_done_at.save
+    @task.restart_done_at
+    @task.save
     redirect_to tasks_url, notice: "Task Visited!"
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -26,14 +26,19 @@ class Task < ActiveRecord::Base
   end
 
   def start_done_at
+    timestamp = done_at || Time.now.in_time_zone
     self.done_at =
       if later.present?
-        Time.now.in_time_zone + later.days
+        timestamp + later.days
       elsif is_daily
-        Time.now.in_time_zone + 1.day
+        timestamp + 1.day
       else
-        Time.now.in_time_zone
+        timestamp
       end
-    self
+  end
+
+  def restart_done_at
+    self.done_at = nil
+    start_done_at
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
 
   validates :password, presence: true
 
-  validates :email, presence: true,                   
+  validates :email, presence: true,
                   format: /\A\S+@\S+\z/,
                   uniqueness: { case_sensitive: false }
 end

--- a/lib/tasks/sqlite_boolean.rake
+++ b/lib/tasks/sqlite_boolean.rake
@@ -1,0 +1,23 @@
+# following instruction as such:
+
+# DEPRECATION WARNING: Leaving `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
+# set to false is deprecated. SQLite databases have used 't' and 'f' to serialize
+# boolean values and must have old data converted to 1 and 0 (its native boolean
+# serialization) before setting this flag to true. Conversion can be accomplished
+# by setting up a rake task which runs
+
+#   ExampleModel.where("boolean_column = 't'").update_all(boolean_column: 1)
+#   ExampleModel.where("boolean_column = 'f'").update_all(boolean_column: 0)
+
+# for all models and all boolean columns, after which the flag must be set to
+# true by adding the following to your application.rb file:
+
+#   Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+#
+namespace :sqlite_boolean do
+  desc "Convert t and f to 1 and 0 for SQLite boolean columns"
+  task convert: :environment do
+    Task.where("is_daily = 't'").update_all(is_daily: 1)
+    Task.where("is_daily = 'f'").update_all(is_daily: 0)
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -25,12 +25,44 @@ describe Task do
     end
   end
 
-  describe '.start_done_at' do
-    it "sets done_at value" do
+  describe '.restart_done_at' do
+    it "sets done_at value with daily" do
+      task = Task.new(task_attributes)
+      task.restart_done_at
+      expect(task).not_to be_persisted
+      expect(task.done_at.to_date).to eq Date.today + 1
+    end
+
+    it "sets done_at value with later" do
       task = Task.new(task_attributes(later: 3))
-      task.start_done_at
+      task.restart_done_at
       expect(task).not_to be_persisted
       expect(task.done_at.to_date).to eq Date.today + 3
+    end
+
+    it "sets done_at value without later" do
+      task = Task.new(task_attributes(later: nil, is_daily: false))
+      task.restart_done_at
+      expect(task).not_to be_persisted
+      expect(task.done_at.to_date).to eq Date.today
+    end
+  end
+
+  describe '.start_done_at' do
+    it "sets done_at value with later" do
+      timestamp = Time.new(2010, 10, 10)
+      task = Task.new(done_at: timestamp, later: 3)
+      task.start_done_at
+      expect(task).not_to be_persisted
+      expect(task.done_at.to_date).to eq timestamp.to_date + 3
+    end
+
+    it "sets done_at value without later" do
+      timestamp = Time.new(2010, 10, 10)
+      task = Task.new(done_at: timestamp, later: nil)
+      task.start_done_at
+      expect(task).not_to be_persisted
+      expect(task.done_at.to_date).to eq timestamp.to_date
     end
   end
 


### PR DESCRIPTION
We recently introduced a bug that `done_at` becomes `Time.now.in_time_zone` when adding a new task with whatever input value of `done_at` in the form. This PR fixes that bug and do other things:

+ Add a rake task that converts boolean in sqlite3 (that means it's used for local development only)
+ Refactor around `done_at` code.